### PR TITLE
Missed badges.less

### DIFF
--- a/app/assets/stylesheets/full_control/index.css.less
+++ b/app/assets/stylesheets/full_control/index.css.less
@@ -32,6 +32,7 @@
 @import "twitter/bootstrap/accordion";
 @import "twitter/bootstrap/carousel";
 @import "twitter/bootstrap/hero-unit";
+@import "twitter/bootstrap/badges";
 @import "twitter/bootstrap/utilities";
 
 #foo {


### PR DESCRIPTION
Hi,

you are missing the badges.less file in your example app. With this patch your example will reflect the complete Twitter Bootstrap v2.0.2 feature set with the exeption of responsive layouts. 

Regards

Nicolai
