### PR TITLE
Update app/assets/stylesheets/full_control/index.css.less

### DIFF
--- a/app/assets/stylesheets/full_control/index.css.less
+++ b/app/assets/stylesheets/full_control/index.css.less
@@ -27,12 +27,11 @@
 @import "twitter/bootstrap/tooltip";
 @import "twitter/bootstrap/popovers";
 @import "twitter/bootstrap/thumbnails";
-@import "twitter/bootstrap/labels";
+@import "twitter/bootstrap/labels-badges";
 @import "twitter/bootstrap/progress-bars";
 @import "twitter/bootstrap/accordion";
 @import "twitter/bootstrap/carousel";
 @import "twitter/bootstrap/hero-unit";
-@import "twitter/bootstrap/badges";
 @import "twitter/bootstrap/utilities";
 
 #foo {


### PR DESCRIPTION
Fixed reference to labels/badges for latest version of less-rails-bootstrap
