### PR TITLE
fix wrong import of labels and badges in full_controll index file

### DIFF
--- a/app/assets/stylesheets/full_control/index.css.less
+++ b/app/assets/stylesheets/full_control/index.css.less
@@ -27,12 +27,11 @@
 @import "twitter/bootstrap/tooltip";
 @import "twitter/bootstrap/popovers";
 @import "twitter/bootstrap/thumbnails";
-@import "twitter/bootstrap/labels";
+@import "twitter/bootstrap/labels-badges";
 @import "twitter/bootstrap/progress-bars";
 @import "twitter/bootstrap/accordion";
 @import "twitter/bootstrap/carousel";
 @import "twitter/bootstrap/hero-unit";
-@import "twitter/bootstrap/badges";
 @import "twitter/bootstrap/utilities";
 
 #foo {


### PR DESCRIPTION
as seen here https://github.com/metaskills/less-rails-bootstrap/blob/master/vendor/frameworks/twitter/bootstrap/bootstrap.less labels and badges are now in the same LESS file.
